### PR TITLE
Restructure handlers.v1 to simplify adding new resource types

### DIFF
--- a/pkg/handlers/v1/config_test.go
+++ b/pkg/handlers/v1/config_test.go
@@ -1,0 +1,107 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMissingRequiredFields(t *testing.T) {
+	tc := []struct {
+		Name          string
+		ConfigItem    configurationItem
+		ExpectedError bool
+	}{
+		{
+			Name: "missing-accountID",
+			ConfigItem: configurationItem{
+				AWSAccountID:                 "",
+				AWSRegion:                    "us-west-2",
+				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
+				ResourceID:                   "abc1234",
+				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
+			},
+			ExpectedError: true,
+		},
+		{
+			Name: "missing-region",
+			ConfigItem: configurationItem{
+				AWSAccountID:                 "0123456789012",
+				AWSRegion:                    "",
+				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
+				ResourceID:                   "abc1234",
+				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
+			},
+			ExpectedError: true,
+		},
+		{
+			Name: "missing-time",
+			ConfigItem: configurationItem{
+				AWSAccountID:                 "0123456789012",
+				AWSRegion:                    "us-west-2",
+				ConfigurationItemCaptureTime: "",
+				ResourceID:                   "abc1234",
+				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
+			},
+			ExpectedError: true,
+		},
+		{
+			Name: "missing-resourceID",
+			ConfigItem: configurationItem{
+				AWSAccountID:                 "0123456789012",
+				AWSRegion:                    "us-west-2",
+				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
+				ResourceID:                   "",
+				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
+			},
+			ExpectedError: true,
+		},
+		{
+			Name: "missing-resource-type",
+			ConfigItem: configurationItem{
+				AWSAccountID:                 "0123456789012",
+				AWSRegion:                    "us-west-2",
+				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
+				ResourceID:                   "abc1234",
+				ResourceType:                 "",
+			},
+			ExpectedError: true,
+		},
+		{
+			Name: "empty tags",
+			ConfigItem: configurationItem{
+				AWSAccountID:                 "0123456789012",
+				AWSRegion:                    "us-west-2",
+				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
+				ResourceID:                   "abc1234",
+				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
+			},
+			ExpectedError: true,
+		},
+		{
+			Name: "valid",
+			ConfigItem: configurationItem{
+				AWSAccountID:                 "0123456789012",
+				AWSRegion:                    "us-west-2",
+				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
+				ResourceID:                   "abc1234",
+				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
+				Tags:                         map[string]string{"foo": "bar"},
+			},
+			ExpectedError: false,
+		},
+	}
+
+	for _, tt := range tc {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			_, err := getBaseOutput(tt.ConfigItem)
+			if tt.ExpectedError {
+				require.NotNil(t, err)
+				return
+			}
+			require.Nil(t, err)
+		})
+	}
+}

--- a/pkg/handlers/v1/ec2.go
+++ b/pkg/handlers/v1/ec2.go
@@ -61,87 +61,101 @@ type ec2ConfigurationDiff struct {
 	ChangeType    string            `json:"changeType"`
 }
 
-func ec2Output(event awsConfigEvent) (Output, error) {
+type ec2Transformer struct{}
+
+func (t ec2Transformer) Create(event awsConfigEvent) (Output, error) {
 	output, err := getBaseOutput(event.ConfigurationItem)
 	if err != nil {
 		return Output{}, err
 	}
-	switch event.ConfigurationItemDiff.ChangeType {
-	case create:
-		if len(output.Tags) == 0 {
-			return Output{}, ErrMissingValue{Field: "Tags"}
-		}
-		// if a resource is created for the first time, there is no diff.
-		// just read the configuration
-		var config ec2Configuration
-		if err := json.Unmarshal(event.ConfigurationItem.Configuration, &config); err != nil {
-			return Output{}, err
-		}
-		change := extractEC2NetworkInfo(&config)
-		change.ChangeType = added
-		output.Changes = append(output.Changes, change)
-	case update:
-		if len(output.Tags) == 0 {
-			return Output{}, ErrMissingValue{Field: "Tags"}
-		}
-		addedChange := Change{ChangeType: added}
-		deletedChange := Change{ChangeType: deleted}
-		// If an update was detected, check to see if any changes to the NetworkInterfaces occurred
-		for k, v := range event.ConfigurationItemDiff.ChangedProperties {
-			if !strings.HasPrefix(k, "Configuration.NetworkInterfaces.") {
-				continue
-			}
-			var diff networkInterfaceDiff
-			if err := json.Unmarshal(v, &diff); err != nil {
-				return Output{}, err
-			}
-			ni := diff.UpdatedValue
-			changes := &addedChange
-			if diff.ChangeType == delete {
-				ni = diff.PreviousValue
-				changes = &deletedChange
-			}
-			private, public, dns := extractNetworkInterfaceInfo(ni)
-			changes.PrivateIPAddresses = append(changes.PrivateIPAddresses, private...)
-			changes.PublicIPAddresses = append(changes.PublicIPAddresses, public...)
-			changes.Hostnames = append(changes.Hostnames, dns...)
-		}
-
-		// We need to compute the symmetric difference of the added changes and the removed changes
-		// i.e. remove entries that show up as both added and removed
-		symmetricDifference(&addedChange, &deletedChange)
-		if len(addedChange.PrivateIPAddresses) > 0 || len(addedChange.PublicIPAddresses) > 0 || len(addedChange.Hostnames) > 0 {
-			output.Changes = append(output.Changes, addedChange)
-		}
-		if len(deletedChange.PrivateIPAddresses) > 0 || len(deletedChange.PublicIPAddresses) > 0 || len(deletedChange.Hostnames) > 0 {
-			output.Changes = append(output.Changes, deletedChange)
-		}
-	case delete:
-		// if a resource is deleted, the tags are no longer present in the base object.
-		// we must fetch them from the previous configuration.
-		changeProps := event.ConfigurationItemDiff.ChangedProperties
-		configDiffRaw, ok := changeProps["Configuration"]
-		if !ok {
-			return Output{}, errors.New("Invalid configuration diff")
-		}
-		var configDiff ec2ConfigurationDiff
-		if err := json.Unmarshal(configDiffRaw, &configDiff); err != nil {
-			return Output{}, err
-		}
-		if configDiff.PreviousValue.Tags == nil || len(configDiff.PreviousValue.Tags) == 0 {
-			return Output{}, ErrMissingValue{Field: "Tags"}
-		}
-		for _, tag := range configDiff.PreviousValue.Tags {
-			output.Tags[tag.Key] = tag.Value
-		}
-
-		// fetch network information from the previous configuration
-		change := extractEC2NetworkInfo(configDiff.PreviousValue)
-		change.ChangeType = deleted
-		output.Changes = append(output.Changes, change)
-	default: // NONE
-		return Output{}, nil
+	if len(output.Tags) == 0 {
+		return Output{}, ErrMissingValue{Field: "Tags"}
 	}
+
+	// if a resource is created for the first time, there is no diff.
+	// just read the configuration
+	var config ec2Configuration
+	if err := json.Unmarshal(event.ConfigurationItem.Configuration, &config); err != nil {
+		return Output{}, err
+	}
+	change := extractEC2NetworkInfo(&config)
+	change.ChangeType = added
+	output.Changes = append(output.Changes, change)
+	return output, nil
+}
+
+func (t ec2Transformer) Update(event awsConfigEvent) (Output, error) {
+	output, err := getBaseOutput(event.ConfigurationItem)
+	if err != nil {
+		return Output{}, err
+	}
+	if len(output.Tags) == 0 {
+		return Output{}, ErrMissingValue{Field: "Tags"}
+	}
+
+	addedChange := Change{ChangeType: added}
+	deletedChange := Change{ChangeType: deleted}
+	// If an update was detected, check to see if any changes to the NetworkInterfaces occurred
+	for k, v := range event.ConfigurationItemDiff.ChangedProperties {
+		if !strings.HasPrefix(k, "Configuration.NetworkInterfaces.") {
+			continue
+		}
+		var diff networkInterfaceDiff
+		if err := json.Unmarshal(v, &diff); err != nil {
+			return Output{}, err
+		}
+		ni := diff.UpdatedValue
+		changes := &addedChange
+		if diff.ChangeType == delete {
+			ni = diff.PreviousValue
+			changes = &deletedChange
+		}
+		private, public, dns := extractNetworkInterfaceInfo(ni)
+		changes.PrivateIPAddresses = append(changes.PrivateIPAddresses, private...)
+		changes.PublicIPAddresses = append(changes.PublicIPAddresses, public...)
+		changes.Hostnames = append(changes.Hostnames, dns...)
+	}
+
+	// We need to compute the symmetric difference of the added changes and the removed changes
+	// i.e. remove entries that show up as both added and removed
+	symmetricDifference(&addedChange, &deletedChange)
+	if len(addedChange.PrivateIPAddresses) > 0 || len(addedChange.PublicIPAddresses) > 0 || len(addedChange.Hostnames) > 0 {
+		output.Changes = append(output.Changes, addedChange)
+	}
+	if len(deletedChange.PrivateIPAddresses) > 0 || len(deletedChange.PublicIPAddresses) > 0 || len(deletedChange.Hostnames) > 0 {
+		output.Changes = append(output.Changes, deletedChange)
+	}
+	return output, nil
+}
+
+func (t ec2Transformer) Delete(event awsConfigEvent) (Output, error) {
+	output, err := getBaseOutput(event.ConfigurationItem)
+	if err != nil {
+		return Output{}, err
+	}
+
+	// if a resource is deleted, the tags are no longer present in the base object.
+	// we must fetch them from the previous configuration.
+	changeProps := event.ConfigurationItemDiff.ChangedProperties
+	configDiffRaw, ok := changeProps["Configuration"]
+	if !ok {
+		return Output{}, errors.New("Invalid configuration diff")
+	}
+	var configDiff ec2ConfigurationDiff
+	if err := json.Unmarshal(configDiffRaw, &configDiff); err != nil {
+		return Output{}, err
+	}
+	if configDiff.PreviousValue.Tags == nil || len(configDiff.PreviousValue.Tags) == 0 {
+		return Output{}, ErrMissingValue{Field: "Tags"}
+	}
+	for _, tag := range configDiff.PreviousValue.Tags {
+		output.Tags[tag.Key] = tag.Value
+	}
+
+	// fetch network information from the previous configuration
+	change := extractEC2NetworkInfo(configDiff.PreviousValue)
+	change.ChangeType = deleted
+	output.Changes = append(output.Changes, change)
 	return output, nil
 }
 

--- a/pkg/handlers/v1/elb.go
+++ b/pkg/handlers/v1/elb.go
@@ -26,66 +26,78 @@ func extractELBNetworkInfo(config *elbConfiguration) Change {
 	}
 }
 
-func elbOutput(event awsConfigEvent) (Output, error) {
+type elbTransformer struct{}
+
+func (t elbTransformer) Create(event awsConfigEvent) (Output, error) {
 	output, err := getBaseOutput(event.ConfigurationItem)
 	if err != nil {
 		return Output{}, err
 	}
-	switch event.ConfigurationItemDiff.ChangeType {
-	case create:
-		if len(output.Tags) == 0 {
-			return Output{}, ErrMissingValue{Field: "Tags"}
-		}
-		// if a resource is created for the first time, there is no diff.
-		// just read the configuration
-		var config elbConfiguration
-		if err := json.Unmarshal(event.ConfigurationItem.Configuration, &config); err != nil {
-			return Output{}, err
-		}
-		change := extractELBNetworkInfo(&config)
-		change.ChangeType = added
-		output.Changes = append(output.Changes, change)
-	case update:
-		// DNS names for ELBs cannot be changed, so this case is a largely a no-op.
-		if len(output.Tags) == 0 {
-			return Output{}, ErrMissingValue{Field: "Tags"}
-		}
-	case delete:
-		// if a resource is deleted, the tags are no longer present in the base object.
-		// we must fetch them from the previous configuration.
-		changeProps := event.ConfigurationItemDiff.ChangedProperties
-		configDiffRaw, ok := changeProps["Configuration"]
-		if !ok {
-			return Output{}, ErrMissingValue{Field: "ChangedProperties.Configuration"}
-		}
-		var configDiff elbConfigurationDiff
-		if err := json.Unmarshal(configDiffRaw, &configDiff); err != nil {
-			return Output{}, err
-		}
+	if len(output.Tags) == 0 {
+		return Output{}, ErrMissingValue{Field: "Tags"}
+	}
 
-		// fetch network information from the previous configuration
-		change := extractELBNetworkInfo(configDiff.PreviousValue)
-		change.ChangeType = deleted
-		output.Changes = append(output.Changes, change)
+	// if a resource is created for the first time, there is no diff.
+	// just read the configuration
+	var config elbConfiguration
+	if err := json.Unmarshal(event.ConfigurationItem.Configuration, &config); err != nil {
+		return Output{}, err
+	}
+	change := extractELBNetworkInfo(&config)
+	change.ChangeType = added
+	output.Changes = append(output.Changes, change)
+	return output, nil
+}
 
-		// if a resource is deleted, the tags are no longer present in the base object.
-		// we must fetch them from the previous configuration.
-		supplementaryConfigDiffRaw, ok := changeProps["SupplementaryConfiguration.Tags"]
-		if !ok {
-			return Output{}, ErrMissingValue{Field: "ChangedProperties.SupplementaryConfiguration.Tags"}
-		}
-		var supplementaryConfigDiff supplementaryConfigurationDiff
-		if err := json.Unmarshal(supplementaryConfigDiffRaw, &supplementaryConfigDiff); err != nil {
-			return Output{}, err
-		}
-		if supplementaryConfigDiff.PreviousValue == nil || len(*supplementaryConfigDiff.PreviousValue) == 0 {
-			return Output{}, ErrMissingValue{Field: "Tags"}
-		}
-		for _, tag := range *supplementaryConfigDiff.PreviousValue {
-			output.Tags[tag.Key] = tag.Value
-		}
-	default: // NONE
-		return Output{}, nil
+func (t elbTransformer) Update(event awsConfigEvent) (Output, error) {
+	// DNS names for ELBs cannot be changed, so the update case is a largely a no-op.
+	output, err := getBaseOutput(event.ConfigurationItem)
+	if err != nil {
+		return Output{}, err
+	}
+	if len(output.Tags) == 0 {
+		return Output{}, ErrMissingValue{Field: "Tags"}
+	}
+	return output, nil
+}
+
+func (t elbTransformer) Delete(event awsConfigEvent) (Output, error) {
+	output, err := getBaseOutput(event.ConfigurationItem)
+	if err != nil {
+		return Output{}, err
+	}
+	// if a resource is deleted, the tags are no longer present in the base object.
+	// we must fetch them from the previous configuration.
+	changeProps := event.ConfigurationItemDiff.ChangedProperties
+	configDiffRaw, ok := changeProps["Configuration"]
+	if !ok {
+		return Output{}, ErrMissingValue{Field: "ChangedProperties.Configuration"}
+	}
+	var configDiff elbConfigurationDiff
+	if err := json.Unmarshal(configDiffRaw, &configDiff); err != nil {
+		return Output{}, err
+	}
+
+	// fetch network information from the previous configuration
+	change := extractELBNetworkInfo(configDiff.PreviousValue)
+	change.ChangeType = deleted
+	output.Changes = append(output.Changes, change)
+
+	// if a resource is deleted, the tags are no longer present in the base object.
+	// we must fetch them from the previous configuration.
+	supplementaryConfigDiffRaw, ok := changeProps["SupplementaryConfiguration.Tags"]
+	if !ok {
+		return Output{}, ErrMissingValue{Field: "ChangedProperties.SupplementaryConfiguration.Tags"}
+	}
+	var supplementaryConfigDiff supplementaryConfigurationDiff
+	if err := json.Unmarshal(supplementaryConfigDiffRaw, &supplementaryConfigDiff); err != nil {
+		return Output{}, err
+	}
+	if supplementaryConfigDiff.PreviousValue == nil || len(*supplementaryConfigDiff.PreviousValue) == 0 {
+		return Output{}, ErrMissingValue{Field: "Tags"}
+	}
+	for _, tag := range *supplementaryConfigDiff.PreviousValue {
+		output.Tags[tag.Key] = tag.Value
 	}
 	return output, nil
 }

--- a/pkg/handlers/v1/elb_test.go
+++ b/pkg/handlers/v1/elb_test.go
@@ -168,7 +168,7 @@ func TestTransformELB(t *testing.T) {
 	}
 }
 
-func TestELBOutput(t *testing.T) {
+func TestELBTransformerCreate(t *testing.T) {
 	tc := []struct {
 		Name           string
 		Event          awsConfigEvent
@@ -196,6 +196,80 @@ func TestELBOutput(t *testing.T) {
 			ExpectedError:  ErrMissingValue{Field: "Tags"},
 		},
 		{
+			Name: "elb-unmarsall-error",
+			Event: awsConfigEvent{
+				ConfigurationItem: configurationItem{
+					AWSAccountID:                 "123456789012",
+					AWSRegion:                    "us-west-2",
+					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
+					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
+					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
+					Tags:                         map[string]string{"foo": "bar"},
+					Configuration:                json.RawMessage(`{"dnsname": 1}`),
+				},
+				ConfigurationItemDiff: configurationItemDiff{
+					ChangeType: create,
+				},
+			},
+			ExpectedOutput: Output{},
+			ExpectError:    true,
+			ExpectedError:  &json.UnmarshalTypeError{Value: "number", Offset: 13, Type: reflect.TypeOf(""), Struct: "elbConfiguration", Field: "dnsname"},
+		},
+		{
+			Name: "elb-missing-value",
+			Event: awsConfigEvent{
+				ConfigurationItem: configurationItem{
+					AWSAccountID:                 "",
+					AWSRegion:                    "us-west-2",
+					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
+					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
+					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
+					Tags:                         map[string]string{},
+				},
+				ConfigurationItemDiff: configurationItemDiff{
+					ChangeType: create,
+					ChangedProperties: map[string]json.RawMessage{
+						"SupplementaryConfiguration.Tags": json.RawMessage("{\"previousValue\":null,\"updatedValue\":null,\"changeType\":\"DELETE\"}"),
+					},
+				},
+			},
+			ExpectedOutput: Output{},
+			ExpectError:    true,
+			ExpectedError:  ErrMissingValue{Field: "AWSAccountID"},
+		},
+	}
+
+	for _, tt := range tc {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			et := elbTransformer{}
+			output, err := et.Create(tt.Event)
+			if tt.ExpectError {
+				require.NotNil(t, err)
+				assert.Equal(t, tt.ExpectedError, err)
+			} else {
+				require.Nil(t, err)
+			}
+			assert.Equal(t, tt.ExpectedOutput.AccountID, output.AccountID)
+			assert.Equal(t, tt.ExpectedOutput.Region, output.Region)
+			assert.Equal(t, tt.ExpectedOutput.ResourceID, output.ResourceID)
+			assert.Equal(t, tt.ExpectedOutput.ResourceType, output.ResourceType)
+			assert.Equal(t, tt.ExpectedOutput.Tags, output.Tags)
+			assert.Equal(t, tt.ExpectedOutput.ChangeTime, output.ChangeTime)
+			assert.True(t, reflect.DeepEqual(tt.ExpectedOutput.Changes, output.Changes), "The expected changes were different than the result")
+		})
+	}
+}
+
+func TestELBTransformerUpdate(t *testing.T) {
+	tc := []struct {
+		Name           string
+		Event          awsConfigEvent
+		ExpectedOutput Output
+		ExpectError    bool
+		ExpectedError  error
+	}{
+		{
 			Name: "elb-update-no-tags",
 			Event: awsConfigEvent{
 				ConfigurationItem: configurationItem{
@@ -214,6 +288,60 @@ func TestELBOutput(t *testing.T) {
 			ExpectError:    true,
 			ExpectedError:  ErrMissingValue{Field: "Tags"},
 		},
+		{
+			Name: "elb-missing-value",
+			Event: awsConfigEvent{
+				ConfigurationItem: configurationItem{
+					AWSAccountID:                 "",
+					AWSRegion:                    "us-west-2",
+					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
+					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
+					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
+					Tags:                         map[string]string{},
+				},
+				ConfigurationItemDiff: configurationItemDiff{
+					ChangeType: update,
+					ChangedProperties: map[string]json.RawMessage{
+						"SupplementaryConfiguration.Tags": json.RawMessage("{\"previousValue\":null,\"updatedValue\":null,\"changeType\":\"DELETE\"}"),
+					},
+				},
+			},
+			ExpectedOutput: Output{},
+			ExpectError:    true,
+			ExpectedError:  ErrMissingValue{Field: "AWSAccountID"},
+		},
+	}
+
+	for _, tt := range tc {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			et := elbTransformer{}
+			output, err := et.Update(tt.Event)
+			if tt.ExpectError {
+				require.NotNil(t, err)
+				assert.Equal(t, tt.ExpectedError, err)
+			} else {
+				require.Nil(t, err)
+			}
+			assert.Equal(t, tt.ExpectedOutput.AccountID, output.AccountID)
+			assert.Equal(t, tt.ExpectedOutput.Region, output.Region)
+			assert.Equal(t, tt.ExpectedOutput.ResourceID, output.ResourceID)
+			assert.Equal(t, tt.ExpectedOutput.ResourceType, output.ResourceType)
+			assert.Equal(t, tt.ExpectedOutput.Tags, output.Tags)
+			assert.Equal(t, tt.ExpectedOutput.ChangeTime, output.ChangeTime)
+			assert.True(t, reflect.DeepEqual(tt.ExpectedOutput.Changes, output.Changes), "The expected changes were different than the result")
+		})
+	}
+}
+
+func TestELBTransformerDelete(t *testing.T) {
+	tc := []struct {
+		Name           string
+		Event          awsConfigEvent
+		ExpectedOutput Output
+		ExpectError    bool
+		ExpectedError  error
+	}{
 		{
 			Name: "elb-delete-no-tags",
 			Event: awsConfigEvent{
@@ -282,10 +410,10 @@ func TestELBOutput(t *testing.T) {
 			ExpectedError:  ErrMissingValue{Field: "ChangedProperties.Configuration"},
 		},
 		{
-			Name: "elb-unknown-change-type",
+			Name: "elb-missing-value",
 			Event: awsConfigEvent{
 				ConfigurationItem: configurationItem{
-					AWSAccountID:                 "123456789012",
+					AWSAccountID:                 "",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
 					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
@@ -293,22 +421,68 @@ func TestELBOutput(t *testing.T) {
 					Tags:                         map[string]string{},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
-					ChangeType: "unknown",
+					ChangeType: delete,
 					ChangedProperties: map[string]json.RawMessage{
 						"SupplementaryConfiguration.Tags": json.RawMessage("{\"previousValue\":null,\"updatedValue\":null,\"changeType\":\"DELETE\"}"),
 					},
 				},
 			},
 			ExpectedOutput: Output{},
-			ExpectError:    false,
-			ExpectedError:  nil,
+			ExpectError:    true,
+			ExpectedError:  ErrMissingValue{Field: "AWSAccountID"},
+		},
+		{
+			Name: "elb-unmarsall-error",
+			Event: awsConfigEvent{
+				ConfigurationItem: configurationItem{
+					AWSAccountID:                 "123456789012",
+					AWSRegion:                    "us-west-2",
+					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
+					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
+					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
+					Tags:                         map[string]string{"foo": "bar"},
+				},
+				ConfigurationItemDiff: configurationItemDiff{
+					ChangeType: delete,
+					ChangedProperties: map[string]json.RawMessage{
+						"Configuration": json.RawMessage(`{"PreviousValue": 1}`),
+					},
+				},
+			},
+			ExpectedOutput: Output{},
+			ExpectError:    true,
+			ExpectedError:  &json.UnmarshalTypeError{Value: "number", Offset: 19, Type: reflect.TypeOf(elbConfiguration{}), Struct: "elbConfigurationDiff", Field: "previousValue"},
+		},
+		{
+			Name: "elb-unmarsall-supplementary-config-error",
+			Event: awsConfigEvent{
+				ConfigurationItem: configurationItem{
+					AWSAccountID:                 "123456789012",
+					AWSRegion:                    "us-west-2",
+					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
+					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
+					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
+					Tags:                         map[string]string{"foo": "bar"},
+				},
+				ConfigurationItemDiff: configurationItemDiff{
+					ChangeType: delete,
+					ChangedProperties: map[string]json.RawMessage{
+						"Configuration":                   json.RawMessage("{\"previousValue\":{\"loadBalancerName\":\"config-test-elb\",\"canonicalHostedZoneNameID\":\"Z1H1FL5HABSF5\",\"listenerDescriptions\":[{\"listener\":{\"protocol\":\"HTTP\",\"loadBalancerPort\":80,\"instanceProtocol\":\"HTTP\",\"instancePort\":80},\"policyNames\":[]}],\"policies\":{\"appCookieStickinessPolicies\":[],\"otherPolicies\":[],\"lbcookieStickinessPolicies\":[]},\"backendServerDescriptions\":[],\"availabilityZones\":[\"us-west-2a\",\"us-west-2b\",\"us-west-2c\",\"us-west-2d\"],\"subnets\":[\"subnet-24b88c41\",\"subnet-7b600d22\",\"subnet-94bbf1e3\",\"subnet-ee4140c6\"],\"sourceSecurityGroup\":{\"ownerAlias\":\"917546781095\",\"groupName\":\"default\"},\"securityGroups\":[\"sg-51164235\"],\"createdTime\":1553713467830,\"scheme\":\"internal\",\"dnsname\":\"internal-config-test-elb-67410663.us-west-2.elb.amazonaws.com\",\"vpcid\":\"vpc-8af6d7ef\"},\"updatedValue\":null,\"changeType\":\"DELETE\"}"),
+						"SupplementaryConfiguration.Tags": json.RawMessage("{\"previousValue\":[{\"key\": 1}],\"updatedValue\":null,\"changeType\":\"DELETE\"}"),
+					},
+				},
+			},
+			ExpectedOutput: Output{},
+			ExpectError:    true,
+			ExpectedError:  &json.UnmarshalTypeError{Value: "number", Offset: 27, Type: reflect.TypeOf(""), Struct: "tag", Field: "key"},
 		},
 	}
 
 	for _, tt := range tc {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
-			output, err := elbOutput(tt.Event)
+			et := elbTransformer{}
+			output, err := et.Delete(tt.Event)
 			if tt.ExpectError {
 				require.NotNil(t, err)
 				assert.Equal(t, tt.ExpectedError, err)

--- a/pkg/handlers/v1/transformer_test.go
+++ b/pkg/handlers/v1/transformer_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/asecurityteam/awsconfig-transformerd/pkg/domain"
 	"github.com/asecurityteam/logevent"
 	"github.com/asecurityteam/runhttp"
-	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,105 +48,6 @@ func TestTransformInvalidJSON(t *testing.T) {
 	transformer := &Transformer{}
 	_, err := transformer.Handle(context.Background(), Input{Message: "not json"})
 	assert.NotNil(t, err, "expected non-nil")
-}
-
-func TestMissingRequiredFields(t *testing.T) {
-	tc := []struct {
-		Name          string
-		ConfigItem    configurationItem
-		ExpectedError bool
-	}{
-		{
-			Name: "missing-accountID",
-			ConfigItem: configurationItem{
-				AWSAccountID:                 "",
-				AWSRegion:                    "us-west-2",
-				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
-				ResourceID:                   "abc1234",
-				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
-			},
-			ExpectedError: true,
-		},
-		{
-			Name: "missing-region",
-			ConfigItem: configurationItem{
-				AWSAccountID:                 "0123456789012",
-				AWSRegion:                    "",
-				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
-				ResourceID:                   "abc1234",
-				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
-			},
-			ExpectedError: true,
-		},
-		{
-			Name: "missing-time",
-			ConfigItem: configurationItem{
-				AWSAccountID:                 "0123456789012",
-				AWSRegion:                    "us-west-2",
-				ConfigurationItemCaptureTime: "",
-				ResourceID:                   "abc1234",
-				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
-			},
-			ExpectedError: true,
-		},
-		{
-			Name: "missing-resourceID",
-			ConfigItem: configurationItem{
-				AWSAccountID:                 "0123456789012",
-				AWSRegion:                    "us-west-2",
-				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
-				ResourceID:                   "",
-				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
-			},
-			ExpectedError: true,
-		},
-		{
-			Name: "missing-resource-type",
-			ConfigItem: configurationItem{
-				AWSAccountID:                 "0123456789012",
-				AWSRegion:                    "us-west-2",
-				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
-				ResourceID:                   "abc1234",
-				ResourceType:                 "",
-			},
-			ExpectedError: true,
-		},
-		{
-			Name: "empty tags",
-			ConfigItem: configurationItem{
-				AWSAccountID:                 "0123456789012",
-				AWSRegion:                    "us-west-2",
-				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
-				ResourceID:                   "abc1234",
-				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
-			},
-			ExpectedError: true,
-		},
-		{
-			Name: "valid",
-			ConfigItem: configurationItem{
-				AWSAccountID:                 "0123456789012",
-				AWSRegion:                    "us-west-2",
-				ConfigurationItemCaptureTime: "2019-02-22T20:19:20.543Z",
-				ResourceID:                   "abc1234",
-				ResourceType:                 configservice.ResourceTypeAwsEc2Instance,
-				Tags:                         map[string]string{"foo": "bar"},
-			},
-			ExpectedError: false,
-		},
-	}
-
-	for _, tt := range tc {
-		tt := tt
-		t.Run(tt.Name, func(t *testing.T) {
-			_, err := getBaseOutput(tt.ConfigItem)
-			if tt.ExpectedError {
-				require.NotNil(t, err)
-				return
-			}
-			require.Nil(t, err)
-		})
-	}
 }
 
 func TestTransformEC2(t *testing.T) {


### PR DESCRIPTION
* Add a ResourceTransformer interface which all new resource types should implement
* Move create/update/delete switch statement into a function to make it more reuseable
* Reorganize tests and files more clearly