### PR TITLE
remove resourceID

### DIFF
--- a/pkg/handlers/v1/config.go
+++ b/pkg/handlers/v1/config.go
@@ -62,9 +62,6 @@ func getBaseOutput(c configurationItem) (Output, error) {
 	if c.ConfigurationItemCaptureTime == "" {
 		return Output{}, ErrMissingValue{Field: "ConfigurationItemCaptureTime"}
 	}
-	if c.ResourceID == "" {
-		return Output{}, ErrMissingValue{Field: "ResourceID"}
-	}
 	if c.ResourceType == "" {
 		return Output{}, ErrMissingValue{Field: "ResourceType"}
 	}
@@ -78,7 +75,6 @@ func getBaseOutput(c configurationItem) (Output, error) {
 		AccountID:    c.AWSAccountID,
 		ChangeTime:   c.ConfigurationItemCaptureTime,
 		Region:       c.AWSRegion,
-		ResourceID:   c.ResourceID,
 		ResourceType: c.ResourceType,
 		ARN:          c.ARN,
 		Tags:         c.Tags,

--- a/pkg/handlers/v1/elb_test.go
+++ b/pkg/handlers/v1/elb_test.go
@@ -26,7 +26,6 @@ func TestTransformELB(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-03-27T19:06:49.363Z",
 				Region:       "us-west-2",
-				ResourceID:   "config-test-elb",
 				ResourceType: "AWS::ElasticLoadBalancing::LoadBalancer",
 				ARN:          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
 				Tags: map[string]string{
@@ -47,7 +46,6 @@ func TestTransformELB(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-03-27T19:12:28.624Z",
 				Region:       "us-west-2",
-				ResourceID:   "config-test-elb",
 				ResourceType: "AWS::ElasticLoadBalancing::LoadBalancer",
 				ARN:          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
 				Tags: map[string]string{
@@ -63,7 +61,6 @@ func TestTransformELB(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-03-27T19:16:23.926Z",
 				Region:       "us-west-2",
-				ResourceID:   "config-test-elb",
 				ResourceType: "AWS::ElasticLoadBalancing::LoadBalancer",
 				ARN:          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
 				Tags: map[string]string{
@@ -85,8 +82,7 @@ func TestTransformELB(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-03-27T19:08:40.855Z",
 				Region:       "us-west-2",
-				ResourceID:   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
-				ARN:          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+				ARN:          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 				ResourceType: "AWS::ElasticLoadBalancingV2::LoadBalancer",
 				Tags: map[string]string{
 					"key1": "1",
@@ -106,8 +102,7 @@ func TestTransformELB(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-03-27T19:12:03.211Z",
 				Region:       "us-west-2",
-				ResourceID:   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
-				ARN:          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+				ARN:          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 				ResourceType: "AWS::ElasticLoadBalancingV2::LoadBalancer",
 				Tags: map[string]string{
 					"key1": "1",
@@ -122,8 +117,7 @@ func TestTransformELB(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-03-27T19:16:22.178Z",
 				Region:       "us-west-2",
-				ResourceID:   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
-				ARN:          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+				ARN:          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 				ResourceType: "AWS::ElasticLoadBalancingV2::LoadBalancer",
 				Tags: map[string]string{
 					"key1": "1",
@@ -165,7 +159,7 @@ func TestTransformELB(t *testing.T) {
 
 			assert.Equal(t, tt.ExpectedOutput.AccountID, output.AccountID)
 			assert.Equal(t, tt.ExpectedOutput.Region, output.Region)
-			assert.Equal(t, tt.ExpectedOutput.ResourceID, output.ResourceID)
+			assert.Equal(t, tt.ExpectedOutput.ARN, output.ARN)
 			assert.Equal(t, tt.ExpectedOutput.ResourceType, output.ResourceType)
 			assert.Equal(t, tt.ExpectedOutput.Tags, output.Tags)
 			assert.Equal(t, tt.ExpectedOutput.ChangeTime, output.ChangeTime)
@@ -189,9 +183,8 @@ func TestELBTransformerCreate(t *testing.T) {
 					AWSAccountID:                 "123456789012",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -209,9 +202,8 @@ func TestELBTransformerCreate(t *testing.T) {
 					AWSAccountID:                 "123456789012",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{"foo": "bar"},
 					Configuration:                json.RawMessage(`{"dnsname": 1}`),
 				},
@@ -230,9 +222,8 @@ func TestELBTransformerCreate(t *testing.T) {
 					AWSAccountID:                 "",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -261,7 +252,7 @@ func TestELBTransformerCreate(t *testing.T) {
 			}
 			assert.Equal(t, tt.ExpectedOutput.AccountID, output.AccountID)
 			assert.Equal(t, tt.ExpectedOutput.Region, output.Region)
-			assert.Equal(t, tt.ExpectedOutput.ResourceID, output.ResourceID)
+			assert.Equal(t, tt.ExpectedOutput.ARN, output.ARN)
 			assert.Equal(t, tt.ExpectedOutput.ResourceType, output.ResourceType)
 			assert.Equal(t, tt.ExpectedOutput.Tags, output.Tags)
 			assert.Equal(t, tt.ExpectedOutput.ChangeTime, output.ChangeTime)
@@ -285,9 +276,8 @@ func TestELBTransformerUpdate(t *testing.T) {
 					AWSAccountID:                 "123456789012",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -305,9 +295,8 @@ func TestELBTransformerUpdate(t *testing.T) {
 					AWSAccountID:                 "",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -336,7 +325,7 @@ func TestELBTransformerUpdate(t *testing.T) {
 			}
 			assert.Equal(t, tt.ExpectedOutput.AccountID, output.AccountID)
 			assert.Equal(t, tt.ExpectedOutput.Region, output.Region)
-			assert.Equal(t, tt.ExpectedOutput.ResourceID, output.ResourceID)
+			assert.Equal(t, tt.ExpectedOutput.ARN, output.ARN)
 			assert.Equal(t, tt.ExpectedOutput.ResourceType, output.ResourceType)
 			assert.Equal(t, tt.ExpectedOutput.Tags, output.Tags)
 			assert.Equal(t, tt.ExpectedOutput.ChangeTime, output.ChangeTime)
@@ -360,9 +349,8 @@ func TestELBTransformerDelete(t *testing.T) {
 					AWSAccountID:                 "123456789012",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -384,9 +372,8 @@ func TestELBTransformerDelete(t *testing.T) {
 					AWSAccountID:                 "123456789012",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -407,9 +394,8 @@ func TestELBTransformerDelete(t *testing.T) {
 					AWSAccountID:                 "123456789012",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -430,9 +416,8 @@ func TestELBTransformerDelete(t *testing.T) {
 					AWSAccountID:                 "",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -453,9 +438,8 @@ func TestELBTransformerDelete(t *testing.T) {
 					AWSAccountID:                 "123456789012",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{"foo": "bar"},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -476,9 +460,8 @@ func TestELBTransformerDelete(t *testing.T) {
 					AWSAccountID:                 "123456789012",
 					AWSRegion:                    "us-west-2",
 					ConfigurationItemCaptureTime: "2019-03-27T19:06:49.363Z",
-					ResourceID:                   "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					ResourceType:                 "AWS::ElasticLoadBalancingV2::LoadBalancer",
-					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/config-test-elb",
+					ARN:                          "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/config-test-alb/5be197427c282f61",
 					Tags:                         map[string]string{"foo": "bar"},
 				},
 				ConfigurationItemDiff: configurationItemDiff{
@@ -508,7 +491,6 @@ func TestELBTransformerDelete(t *testing.T) {
 			}
 			assert.Equal(t, tt.ExpectedOutput.AccountID, output.AccountID)
 			assert.Equal(t, tt.ExpectedOutput.Region, output.Region)
-			assert.Equal(t, tt.ExpectedOutput.ResourceID, output.ResourceID)
 			assert.Equal(t, tt.ExpectedOutput.ResourceType, output.ResourceType)
 			assert.Equal(t, tt.ExpectedOutput.Tags, output.Tags)
 			assert.Equal(t, tt.ExpectedOutput.ChangeTime, output.ChangeTime)

--- a/pkg/handlers/v1/transformer.go
+++ b/pkg/handlers/v1/transformer.go
@@ -43,9 +43,6 @@ type Output struct {
 	// Region is the AWS region (required)
 	Region string `json:"region"`
 
-	// ResourceID is the ID of the AWS resource (required)
-	ResourceID string `json:"resourceId"`
-
 	// ARN is the Amazon Resource Name (required)
 	ARN string `json:"arn"`
 

--- a/pkg/handlers/v1/transformer_test.go
+++ b/pkg/handlers/v1/transformer_test.go
@@ -66,7 +66,6 @@ func TestTransformEC2(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-02-22T20:43:10.208Z",
 				Region:       "us-west-2",
-				ResourceID:   "i-0a763ac3ee37d8d2b",
 				ResourceType: "AWS::EC2::Instance",
 				ARN:          "arn:aws:ec2:us-west-2:123456789012:instance/i-0a763ac3ee37d8d2b",
 				Tags: map[string]string{
@@ -90,7 +89,6 @@ func TestTransformEC2(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-02-22T20:48:32.538Z",
 				Region:       "us-west-2",
-				ResourceID:   "i-0a763ac3ee37d8d2b",
 				ResourceType: "AWS::EC2::Instance",
 				ARN:          "arn:aws:ec2:us-west-2:123456789012:instance/i-0a763ac3ee37d8d2b",
 				Tags: map[string]string{
@@ -114,7 +112,6 @@ func TestTransformEC2(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-02-22T21:02:18.758Z",
 				Region:       "us-west-2",
-				ResourceID:   "i-0a763ac3ee37d8d2b",
 				ResourceType: "AWS::EC2::Instance",
 				ARN:          "arn:aws:ec2:us-west-2:123456789012:instance/i-0a763ac3ee37d8d2b",
 				Tags: map[string]string{
@@ -138,7 +135,6 @@ func TestTransformEC2(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-02-22T21:17:53.073Z",
 				Region:       "us-west-2",
-				ResourceID:   "i-0a763ac3ee37d8d2b",
 				ResourceType: "AWS::EC2::Instance",
 				ARN:          "arn:aws:ec2:us-west-2:123456789012:instance/i-0a763ac3ee37d8d2b",
 				Tags: map[string]string{
@@ -162,7 +158,6 @@ func TestTransformEC2(t *testing.T) {
 				AccountID:    "123456789012",
 				ChangeTime:   "2019-02-22T21:31:57.042Z",
 				Region:       "us-west-2",
-				ResourceID:   "i-0a763ac3ee37d8d2b",
 				ResourceType: "AWS::EC2::Instance",
 				ARN:          "arn:aws:ec2:us-west-2:123456789012:instance/i-0a763ac3ee37d8d2b",
 				Tags: map[string]string{
@@ -204,7 +199,6 @@ func TestTransformEC2(t *testing.T) {
 
 			assert.Equal(t, tt.ExpectedOutput.AccountID, output.AccountID)
 			assert.Equal(t, tt.ExpectedOutput.Region, output.Region)
-			assert.Equal(t, tt.ExpectedOutput.ResourceID, output.ResourceID)
 			assert.Equal(t, tt.ExpectedOutput.ResourceType, output.ResourceType)
 			assert.Equal(t, tt.ExpectedOutput.ARN, output.ARN)
 			assert.Equal(t, tt.ExpectedOutput.Tags, output.Tags)


### PR DESCRIPTION
This PR removes ResourceID from the output, and will only move forward with ARN. The reason being is that ARNs will contain the resourceID, and arns are typically used for identification purposed within the AWS ecosystem.