### PR TITLE
fixing broken linting checks

### DIFF
--- a/pkg/handlers/v1/ec2.go
+++ b/pkg/handlers/v1/ec2.go
@@ -202,8 +202,8 @@ func sliceDiff(a, b []string) []string {
 // extract network interface information from an ec2 configuration
 func extractEC2NetworkInfo(config *ec2Configuration) Change {
 	change := Change{}
-	for _, ni := range config.NetworkInterfaces {
-		private, public, dns := extractNetworkInterfaceInfo(&ni)
+	for i := range config.NetworkInterfaces {
+		private, public, dns := extractNetworkInterfaceInfo(&config.NetworkInterfaces[i])
 		change.PrivateIPAddresses = append(change.PrivateIPAddresses, private...)
 		change.PublicIPAddresses = append(change.PublicIPAddresses, public...)
 		change.Hostnames = append(change.Hostnames, dns...)

--- a/pkg/handlers/v1/eni.go
+++ b/pkg/handlers/v1/eni.go
@@ -51,7 +51,7 @@ func (t eniTransformer) Create(event awsConfigEvent) (Output, error) {
 
 // Returns true if we should filter this event due to not being requester managed
 func filter(config eniConfiguration) bool {
-	return config.RequesterManaged == false || config.RequesterID != elbRequester
+	return !config.RequesterManaged || config.RequesterID != elbRequester
 }
 
 func (t eniTransformer) Update(event awsConfigEvent) (Output, error) {

--- a/pkg/handlers/v1/transformer_test.go
+++ b/pkg/handlers/v1/transformer_test.go
@@ -32,7 +32,7 @@ func TestAWSConfigEventMarshalling(t *testing.T) {
 	res := awsConfigEvent{}
 	_ = json.Unmarshal(data, &res)
 
-	assert.NotNil(t, res.ConfigurationItemDiff.ChangedProperties, "marshalling should have resulted in non-nil value")
+	assert.NotNil(t, res.ConfigurationItemDiff.ChangedProperties, "marshaling should have resulted in non-nil value")
 	marshaled, _ := json.MarshalIndent(res, "", "    ")
 
 	assert.JSONEq(t, string(data), string(marshaled))
@@ -40,9 +40,9 @@ func TestAWSConfigEventMarshalling(t *testing.T) {
 
 func TestTransformEmptiness(t *testing.T) {
 	event := awsConfigEvent{}
-	marshalled, _ := json.Marshal(event)
+	marshaled, _ := json.Marshal(event)
 	transformer := &Transformer{LogFn: logFn}
-	output, err := transformer.Handle(context.Background(), Input{Message: string(marshalled)})
+	output, err := transformer.Handle(context.Background(), Input{Message: string(marshaled)})
 	assert.Nil(t, err, "expected non-nil")
 	assert.Equal(t, 0, len(output.Changes))
 }


### PR DESCRIPTION
Fixes broken linting failures:
```
INFO [runner] linters took 5.4759663s with stages: goanalysis_metalinter: 5.4573111s 
pkg/handlers/v1/ec2.go:206:55: G601: Implicit memory aliasing in for loop. (gosec)
                private, public, dns := extractNetworkInterfaceInfo(&ni)
                                                                    ^
pkg/handlers/v1/transformer_test.go:35:65: `marshalling` is a misspelling of `marshaling` (misspell)
        assert.NotNil(t, res.ConfigurationItemDiff.ChangedProperties, "marshalling should have resulted in non-nil value")
                                                                       ^
pkg/handlers/v1/transformer_test.go:43:2: `marshalled` is a misspelling of `marshaled` (misspell)
        marshalled, _ := json.Marshal(event)
        ^
pkg/handlers/v1/transformer_test.go:45:80: `marshalled` is a misspelling of `marshaled` (misspell)
        output, err := transformer.Handle(context.Background(), Input{Message: string(marshalled)})
                                                                                      ^
pkg/handlers/v1/eni.go:54:9: S1002: should omit comparison to bool constant, can be simplified to `!config.RequesterManaged` (gosimple)
        return config.RequesterManaged == false || config.RequesterID != elbRequester
```
