### PR TITLE
Fix ELB unit tests to check tag changes correctly

### DIFF
--- a/pkg/handlers/v1/eni_test.go
+++ b/pkg/handlers/v1/eni_test.go
@@ -92,7 +92,7 @@ func TestTransformENI(t *testing.T) {
 			assert.Equal(t, tt.ExpectedOutput.ARN, output.ARN)
 			assert.Equal(t, tt.ExpectedOutput.ResourceType, output.ResourceType)
 			assert.Equal(t, tt.ExpectedOutput.ChangeTime, output.ChangeTime)
-			assert.True(t, reflect.DeepEqual(tt.ExpectedOutput.Changes, output.Changes), "The expected changes were different than the result")
+			assert.ElementsMatch(t, tt.ExpectedOutput.Changes, output.Changes)
 		})
 	}
 }

--- a/pkg/handlers/v1/transformer_test.go
+++ b/pkg/handlers/v1/transformer_test.go
@@ -283,7 +283,7 @@ func TestTransformEC2(t *testing.T) {
 			assert.Equal(t, tt.ExpectedOutput.ARN, output.ARN)
 			assert.Equal(t, tt.ExpectedOutput.Tags, output.Tags)
 			assert.Equal(t, tt.ExpectedOutput.ChangeTime, output.ChangeTime)
-			assert.True(t, reflect.DeepEqual(tt.ExpectedOutput.Changes, output.Changes), "The expected changes were different than the result")
+			assert.ElementsMatch(t, tt.ExpectedOutput.Changes, output.Changes)
 		})
 	}
 }


### PR DESCRIPTION
- ELB unit tests now check that correct tag changes are returned from the transformer
- Added `ElementsMatch` assertions in various unit tests to verify that returned lists contain the correct items, without regard to ordering. Used to check lists of `Change`s returned by the transformer