### PR TITLE
Check another field for tags

### DIFF
--- a/pkg/handlers/v1/transformer.go
+++ b/pkg/handlers/v1/transformer.go
@@ -157,7 +157,8 @@ func extractTagChanges(ev configurationItemDiff) ([]TagChange, error) {
 	for k, v := range ev.ChangedProperties {
 		if !strings.HasPrefix(k, "Configuration.TagSet.") &&
 			!strings.HasPrefix(k, "SupplementaryConfiguration.TagSet.") &&
-			!strings.HasPrefix(k, "TagSet.") {
+			!strings.HasPrefix(k, "TagSet.") &&
+			!strings.HasPrefix(k, "Configuration.Tags.") {
 			continue
 		}
 		var tc TagChange

--- a/pkg/handlers/v1/transformer_test.go
+++ b/pkg/handlers/v1/transformer_test.go
@@ -329,6 +329,25 @@ func Test_extractTagChanges(t *testing.T) {
 			make([]TagChange, 0),
 			true,
 		},
+		{
+			"tags included",
+			configurationItemDiff{
+				ChangedProperties: map[string]json.RawMessage{
+					"Configuration.Tags.1": json.RawMessage("{\"previousValue\": null, \"updatedValue\": {\"key\": \"info\", \"value\": \"I added a new tag\"}}"),
+				},
+				ChangeType: "ADD",
+			},
+			[]TagChange{
+				{
+					UpdatedValue: &Tag{
+						Key:   "info",
+						Value: "I added a new tag",
+					},
+					PreviousValue: nil,
+				},
+			},
+			true,
+		},
 		// happy path is tested via regular add/del events for resources
 	}
 	for _, tt := range tests {

--- a/pkg/handlers/v1/transformer_test.go
+++ b/pkg/handlers/v1/transformer_test.go
@@ -346,7 +346,7 @@ func Test_extractTagChanges(t *testing.T) {
 					PreviousValue: nil,
 				},
 			},
-			true,
+			false,
 		},
 		// happy path is tested via regular add/del events for resources
 	}


### PR DESCRIPTION
We missed that tag changes can be contained in the `Configuration.Tags` field of awsconfig. This is to add that field as one where we extract tag changes from.

This was tested locally with the AIA pipeline, and seems to work.