### PR TITLE
Ignore EC2 attached ENIs

### DIFF
--- a/pkg/handlers/v1/elb_test.go
+++ b/pkg/handlers/v1/elb_test.go
@@ -321,7 +321,8 @@ func TestELBTransformerCreate(t *testing.T) {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			et := elbTransformer{}
-			output, err := et.Create(tt.Event)
+			output, reject, err := et.Create(tt.Event)
+			assert.Equal(t, false, reject)
 			if tt.ExpectError {
 				require.NotNil(t, err)
 				assert.Equal(t, tt.ExpectedError, err)
@@ -375,7 +376,8 @@ func TestELBTransformerUpdate(t *testing.T) {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			et := elbTransformer{}
-			output, err := et.Update(tt.Event)
+			output, reject, err := et.Update(tt.Event)
+			assert.Equal(t, false, reject)
 			if tt.ExpectError {
 				require.NotNil(t, err)
 				assert.Equal(t, tt.ExpectedError, err)
@@ -561,7 +563,8 @@ func TestELBTransformerDelete(t *testing.T) {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			et := elbTransformer{}
-			output, err := et.Delete(tt.Event)
+			output, reject, err := et.Delete(tt.Event)
+			assert.Equal(t, false, reject)
 			if tt.ExpectError {
 				require.NotNil(t, err)
 				assert.Equal(t, tt.ExpectedError, err)

--- a/pkg/handlers/v1/eni_test.go
+++ b/pkg/handlers/v1/eni_test.go
@@ -132,7 +132,7 @@ func TestFilterENI(t *testing.T) {
 		assert.True(t, createOutput.Changes == nil, "Expected empty changes due to filtering")
 	})
 
-	t.Run("eni-created", func(t *testing.T) {
+	t.Run("eni-created-with-tags", func(t *testing.T) {
 		filteredConfig.RequesterManaged = true
 		filteredConfigEvent.ConfigurationItem.Configuration = json.RawMessage(jsonFilteredConfig)
 		filteredConfigEvent.ConfigurationItem.Tags = map[string]string{
@@ -146,6 +146,7 @@ func TestFilterENI(t *testing.T) {
 	})
 
 	t.Run("eni-deleted", func(t *testing.T) {
+		filteredConfig.RequesterManaged = false
 		// Because deleting looks at the PreviousValue for filtering, we need some more set up
 		filteredConfigDiff := eniConfigurationDiff{PreviousValue: &filteredConfig}
 		jsonFilteredConfigDiff, err := json.Marshal(filteredConfigDiff)

--- a/pkg/handlers/v1/eni_test.go
+++ b/pkg/handlers/v1/eni_test.go
@@ -226,6 +226,13 @@ func TestErrorENI(t *testing.T) {
 	// We would like this to pass evaluation so we can instead test unmarshaling errors for configs
 	malformedConfigEvent.ConfigurationItem.AWSAccountID = "123456789"
 
+	t.Run("malformed-json-update-event", func(t *testing.T) {
+		malformedConfigEvent.ConfigurationItem.Configuration = []byte("{ bad: json }")
+		_, _, err := transformer.Update(malformedConfigEvent)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "invalid character")
+	})
+
 	malformedConfiguration := json.RawMessage(`{"requesterManaged": "sure"}`)
 
 	t.Run("malformed-create-config", func(t *testing.T) {

--- a/pkg/handlers/v1/eni_test.go
+++ b/pkg/handlers/v1/eni_test.go
@@ -124,6 +124,7 @@ func TestFilterENI(t *testing.T) {
 	transformer := eniTransformer{}
 
 	t.Run("eni-created", func(t *testing.T) {
+		filteredConfig.RequesterManaged = false
 		filteredConfigEvent.ConfigurationItem.Configuration = json.RawMessage(jsonFilteredConfig)
 
 		createOutput, reject, err := transformer.Create(filteredConfigEvent)

--- a/pkg/handlers/v1/eni_test.go
+++ b/pkg/handlers/v1/eni_test.go
@@ -128,7 +128,7 @@ func TestFilterENI(t *testing.T) {
 		filteredConfigEvent.ConfigurationItem.Configuration = json.RawMessage(jsonFilteredConfig)
 
 		createOutput, reject, err := transformer.Create(filteredConfigEvent)
-		assert.Equal(t, false, reject)
+		assert.Equal(t, true, reject)
 		assert.Nil(t, err)
 		assert.True(t, createOutput.Changes == nil, "Expected empty changes due to filtering")
 	})


### PR DESCRIPTION
The way we filter out non-requester managed ENIs relies on an empty `changes` array. When an ENI's tags have been updated, that populates the changes array (after our filter condition check) and therefore causes us not to reject it. This should prevent that scenario.